### PR TITLE
research: add --effort low|middle|high to /research:plan

### DIFF
--- a/.agents/skills/research-colon-plan/SKILL.md
+++ b/.agents/skills/research-colon-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research:plan
-description: "Alias for the AnchoredAutoResearch Codex planning wizard. Equivalent intent to $research-plan."
+description: "Alias for the AnchoredAutoResearch Codex planning wizard. Equivalent intent to $research-plan. Supports --effort low|middle|high."
 version: 1.0.0
 ---
 
@@ -8,10 +8,19 @@ version: 1.0.0
 
 Use this skill when the user invokes `$research:plan` in Codex.
 
+Optional flag: `--effort low|middle|high` controls ideation breadth.
+Default is `low` (current behavior). See `### Effort levels` in
+`../research/references/phase-protocol.md` for the per-level protocol.
+Reject any other value with: "unknown effort level — use low, middle, or high".
+
 Follow the same workflow as the `research-plan` skill:
 1. Read `AGENTS.md`
 2. Read `RSD.md`
 3. Read `context/SOURCES.md` if it exists
-4. Follow the PLAN section in `../research/references/phase-protocol.md`
-5. Follow `../research/references/knowledge-sources.md`
-6. Write the PLAN entry, compile, commit, and stop for human approval
+4. Parse `--effort` flag if present and branch on it per the
+   `### Effort levels` section in `../research/references/phase-protocol.md`
+5. Follow the PLAN section in `../research/references/phase-protocol.md`
+6. Follow `../research/references/knowledge-sources.md`
+7. Write the PLAN entry (including `Effort level:` and
+   `Alternatives considered:` fields), compile, commit, and stop for human
+   approval

--- a/.agents/skills/research-plan/SKILL.md
+++ b/.agents/skills/research-plan/SKILL.md
@@ -1,12 +1,17 @@
 ---
 name: research-plan
-description: "AnchoredAutoResearch planning wizard for Codex. Builds the PLAN section with scope, metrics, verify/guard commands, predictions, and human approval gates."
+description: "AnchoredAutoResearch planning wizard for Codex. Builds the PLAN section with scope, metrics, verify/guard commands, predictions, and human approval gates. Supports --effort low|middle|high."
 version: 1.0.0
 ---
 
 # AnchoredAutoResearch — PLAN Entrypoint
 
 Use this skill when the user invokes `$research-plan` in Codex.
+
+Optional flag: `--effort low|middle|high` controls ideation breadth.
+Default is `low` (current behavior). See `### Effort levels` in
+`../research/references/phase-protocol.md` for the per-level protocol.
+Reject any other value with: "unknown effort level — use low, middle, or high".
 
 ## MANDATORY: Read Protocol Before Any Action
 
@@ -18,16 +23,25 @@ Use this skill when the user invokes `$research-plan` in Codex.
 
 ## Execution
 
-1. Treat any remaining user text as inline goal or planning context
+1. Treat any remaining user text as inline goal or planning context.
+   Parse `--effort low|middle|high` if present (default `low`).
 2. Verify the project is in PLAN or can safely enter PLAN from INIT
 3. Read unread sources in `context/`
-4. Build the PLAN entry with:
+4. Branch on effort level per `### Effort levels` in
+   `../research/references/phase-protocol.md`:
+   - `low` → one proposal tied to the user's goal (current behavior)
+   - `middle` → 2-3 candidates, silent auto-pick, log alternatives
+   - `high` → cost gate first; 5-8 candidates spanning sub-topics with at
+     least one cross-field candidate; present via interactive selection
+5. Build the PLAN entry with:
    - goal and hypothesis linkage
-   - grounded-in source citation
+   - grounded-in source citation (every candidate at every effort level)
    - prediction before execution
    - verify and guard commands
    - execution mode
-5. Set `Status: WAITING_HUMAN`
-6. Run `bash scripts/compile_rsd.sh`
-7. Commit the phase boundary
-8. Stop and tell the human to approve or revise in chat or `RSD.md` using any clear wording
+   - `Effort level:` and `Alternatives considered:` fields (use
+     `N/A (low effort)` for the default level)
+6. Set `Status: WAITING_HUMAN`
+7. Run `bash scripts/compile_rsd.sh`
+8. Commit the phase boundary
+9. Stop and tell the human to approve or revise in chat or `RSD.md` using any clear wording

--- a/.claude/commands/research/plan.md
+++ b/.claude/commands/research/plan.md
@@ -1,7 +1,7 @@
 ---
 name: research:plan
-description: "Interactive experiment design wizard. Builds a complete PLAN section for RSD: Goal→Scope→Metric→Verify→Guard→Prediction→Confirm."
-argument-hint: "[goal description]"
+description: "Interactive experiment design wizard. Builds a complete PLAN section for RSD: Goal→Scope→Metric→Verify→Guard→Prediction→Confirm. Supports --effort low|middle|high."
+argument-hint: "[goal description] [--effort low|middle|high]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate before reading the protocol.
@@ -10,7 +10,13 @@ EXECUTE IMMEDIATELY — do not deliberate before reading the protocol.
 
 Extract from $ARGUMENTS:
 - Goal text — if user provides it inline, use as starting point
-- Any flags: `--scope`, `--metric`, `--verify`, `--guard`, `--mode`
+- Any flags: `--scope`, `--metric`, `--verify`, `--guard`, `--mode`, `--effort`
+- `--effort low|middle|high` — exploration breadth for the ideation step.
+  Default: `low` (backward-compatible, same as before the flag was added).
+  See `phase-protocol.md` `### Effort levels` for the per-level protocol.
+  Validate: if `--effort` is present, value MUST be one of `low`, `middle`,
+  `high`. Reject any other value with: "unknown effort level — use low,
+  middle, or high".
 
 ## Execution
 
@@ -29,10 +35,27 @@ If no goal inline, ask:
 - What are we trying to achieve?
 - Link to which hypothesis in the RSD?
 
-### Step 2: Analyze Context
+### Step 2: Analyze Context + Ideate at the chosen effort level
 - Read codebase structure and existing code
 - Read knowledge sources — what does prior work suggest?
 - Identify relevant tools, frameworks, metrics
+- **Branch on effort level** (see `phase-protocol.md` `### Effort levels`
+  for the full per-level protocol):
+  - `low` (default) → one proposal tied to the user's stated goal. No
+    candidate generation. Continue to Step 3.
+  - `middle` → optionally offer `/research:context search` if SURVEY.md
+    is thin; generate 2-3 adjacent candidates; rank by
+    relevance × novelty × feasibility; silently pick the best; remember
+    the rejected candidates for Step 7's `**Alternatives considered:**`
+    field.
+  - `high` → fire the cost gate FIRST (`"This will use significantly more
+    tokens. Proceed?"`); on yes, optionally offer `/research:context
+    search`; generate 5-8 candidates spanning 3+ sub-topics with at
+    least one combination candidate and at least one cross-field
+    candidate when plausible; score each on novelty/feasibility/relevance
+    (1-5 each); present the top 5-8 via `AskUserQuestion` with a "You
+    pick (highest combined score)" delegation option; use the chosen
+    candidate as the seed for Steps 3-6.
 
 ### Step 3: Define Scope
 Present scope options:
@@ -59,7 +82,13 @@ Present scope options:
 
 ### Step 7: Confirm + Write to RSD
 Present complete plan, ask for confirmation, then:
-1. Write PLAN section to RSD.md (per phase-protocol.md format)
+1. Write PLAN section to RSD.md (per phase-protocol.md format) — include
+   the two effort-related fields:
+   - `**Effort level:**` — the effort level used for this invocation
+     (`low` / `middle` / `high`)
+   - `**Alternatives considered:**` — for `middle` / `high`, bullet the
+     rejected candidates from Step 2 with a one-line reason each; for
+     `low`, write `N/A (low effort)`
 2. Set Status: WAITING_HUMAN
 3. Compile PDF
 4. Git commit: "research: cycle N plan"

--- a/.claude/skills/research/references/phase-protocol.md
+++ b/.claude/skills/research/references/phase-protocol.md
@@ -106,6 +106,158 @@ Before proposing any experiment, MUST:
 2. Read any unread sources in `context/`
 3. Update Knowledge Sources table in RSD.md with key takeaways
 
+### Effort levels
+
+`/research:plan` accepts an `--effort low|middle|high` flag that controls
+how widely the ideation step explores before settling on a proposal. The
+default is `low` (backward-compatible — identical to the behavior before
+the effort flag was added).
+
+Effort level is **orthogonal** to Mode A (human proposes, AI refines) vs
+Mode B (AI proposes). A human-proposed core idea with `--effort high`
+means "take my idea and explore wild variations of it". A blank plan
+with `--effort low` is the classic AI-proposes-narrow behavior.
+
+**Regardless of effort level, the final written PLAN block is ONE
+experiment with ONE prediction and ONE metric. Effort affects the
+ideation step, not the output shape.** The rejected alternatives are
+recorded in the `**Alternatives considered:**` field for auditability.
+
+#### LOW (default)
+
+Current behavior verbatim. AI reads RSD + `context/`, proposes ONE
+experiment tied to the user's stated goal, fills the PLAN block. No
+candidate generation, no alternatives. The `**Alternatives considered:**`
+field is written as `N/A (low effort)`.
+
+Use LOW for incremental research, well-defined problems, time-pressed
+iteration.
+
+#### MIDDLE
+
+Silent-pick mode: AI explores 2-3 adjacent framings, picks the best, logs
+the rest.
+
+1. **Sub-topic detection**: Parse the user's goal into 1-3 sub-topics using
+   the Methods Landscape in `context/SURVEY.md` if present, otherwise from
+   the user's own description.
+2. **SURVEY.md pre-check**: If `context/SURVEY.md` is missing OR has no
+   entries matching the detected sub-topic, **offer once** to run
+   `/research:context search <topic>` first:
+   > "No SURVEY.md entries found for `<topic>`. Run `/research:context
+   > search <topic>` first to build a literature survey? (yes / no / skip)"
+   - `yes` → run the search, then continue
+   - `no` or `skip` → continue with whatever is in `context/` and record a
+     `knowledge gap` note in the final PLAN block
+3. **Generate 2-3 candidates** within the detected sub-topics. Each
+   candidate is a short record: `{direction, 1-line hypothesis, grounded-in
+   citation, estimated cost, 1-line risk}`.
+4. **Rank** by `relevance_to_user_goal × novelty × feasibility` (each
+   scored 1-5). Pick the highest.
+5. **Write** the chosen candidate as the PLAN block. Write the 1-2
+   rejected candidates as bullets in `**Alternatives considered:**` with
+   a one-line reason for rejection each.
+
+MIDDLE does NOT round-trip to the user between start and the final PLAN —
+the standard approval step at the end is the user's only opportunity to
+revise.
+
+Use MIDDLE when you know the area and want a couple of options to be
+considered without burning the tokens of HIGH.
+
+#### HIGH
+
+Wide exploration mode with explicit cross-field ideation and a user
+selection step. This is the token-heavy mode — gate it behind a cost
+prompt at the start.
+
+1. **Cost gate** (MANDATORY first step): Before any candidate generation,
+   tell the user:
+   > "High-effort exploration will generate 5-8 candidate directions
+   > spanning multiple sub-topics, and may invoke web search. This can
+   > use significantly more tokens than low/middle. Proceed? (yes / cancel)"
+   - `cancel` → STOP, tell the user to rerun with `--effort low` or
+     `--effort middle` if they want to continue
+   - `yes` → continue to step 2
+
+2. **SURVEY.md pre-check** (same as MIDDLE step 2, but mandatory to ask):
+   If `context/SURVEY.md` is missing or has no entries for the detected
+   sub-topic, offer once to run `/research:context search <topic>` first.
+   Record the answer. If the user says no/skip, proceed with whatever is
+   in `context/` and mark affected candidates with the explicit "novel —
+   no prior work found" marker.
+
+3. **Wild candidate generation**: Enumerate 5-8 candidate directions
+   spanning multiple sub-topics. The protocol REQUIRES that the set:
+   - Covers at least 3 distinct sub-topics within the user's research
+     area (e.g., for "LLM agents": prompting, memory, context engineering,
+     tool use, RL training, benchmarks, planning, self-reflection,
+     multi-agent coordination)
+   - Includes at least ONE combination candidate (two sub-topics combined,
+     e.g., "memory-aware tool use" or "RL-trained context compression")
+   - Includes at least ONE cross-field / unconventional candidate IF
+     plausible (e.g., applying Genetic Algorithms to prompt optimization,
+     control-theoretic stability bounds for agent loops, economic
+     mechanism design for multi-agent coordination, biology-inspired
+     memory consolidation). If no cross-field analogy is plausible, skip
+     this requirement rather than force a bad one.
+
+   For each candidate, produce this record:
+   ```
+   - Direction: [one line]
+   - Hypothesis: [one line — what you expect to find]
+   - Mechanism sketch: [2-3 lines — how the experiment would work]
+   - Grounded in: [source citation, or "novel — no prior work found, see
+     SURVEY.md gaps"]
+   - Novelty: [1-5]
+   - Feasibility: [1-5]
+   - Relevance: [1-5]
+   - Risk: [one line — what could go wrong]
+   ```
+
+   **Cross-field auditability**: If a candidate applies a method from
+   outside the user's field (e.g., GA for LLM agents), the Mechanism
+   sketch MUST include a one-sentence analogy explaining why the
+   cross-field mechanism plausibly applies. No analogy → drop the
+   candidate.
+
+4. **Rank** by the simple sum `novelty + feasibility + relevance` (range
+   3-15). Ties broken by feasibility (higher wins).
+
+5. **Present to user** via `AskUserQuestion` with the top 5-8 candidates
+   as options. Each option: label is the Direction (short), description
+   is `Hypothesis + "(N=novelty/F=feasibility/R=relevance)"`. Include an
+   explicit extra option labeled "You pick (highest combined score)" so
+   the user can delegate back to the AI.
+
+6. **Write the chosen candidate** as the full PLAN block with
+   `**Effort level:** high`. The rejected candidates go into
+   `**Alternatives considered:**` as bullets — one line each with their
+   combined score and the reason they weren't picked. If the user chose
+   "You pick", the AI picks the highest-score candidate and the
+   `**Alternatives considered:**` bullets include the full ranked list
+   with combined scores.
+
+Use HIGH for early-stage exploration, broad topics ("I want to study LLM
+agents"), or when the user explicitly wants to be surprised.
+
+#### Effort-level guardrails (all levels)
+
+- **Citation is non-negotiable**: every candidate at every effort level
+  MUST cite a `Grounded in:` source — either a SURVEY.md row, a specific
+  paper, or the explicit string "novel — no prior work found, see
+  SURVEY.md gaps". Silent grounding is a protocol violation.
+- **One metric, one prediction**: effort affects ideation breadth, never
+  output shape. The final PLAN block has exactly one metric, one
+  prediction, one experiment — even in HIGH. This preserves the
+  anti-gaming discipline from core-principles.md §2.
+- **No unbounded branching**: MIDDLE caps at 3 candidates, HIGH caps at 8.
+  If the AI generates more during ideation, it must rank and truncate
+  before presenting.
+- **Cost gate is single-shot**: the HIGH cost prompt fires once at the
+  start, not per-candidate. Once the user says yes, run the whole
+  protocol straight through to the selection step without interruption.
+
 ### Write the Plan (two modes)
 
 1. Read RSD.md fully. Review all prior cycles, hypotheses, open questions.
@@ -132,8 +284,13 @@ If no human proposal exists and human says "propose" or leaves PLAN blank:
 ```markdown
 ### PLAN
 **Proposed by:** [human | AI | human-refined-by-AI]
+**Effort level:** [low | middle | high]
 **Proposed:** [what experiment to run and why — link to hypothesis]
 **Grounded in:** [which knowledge source informed this — cite file or URL]
+**Alternatives considered:**
+- [rejected candidate 1 — one line + why rejected]
+- [rejected candidate 2 — one line + why rejected]
+- (or "N/A (low effort)" for low-effort plans)
 **Prediction:** [specific expected outcome — numbers, directions, ranges]
 **If wrong:** [what a failed prediction would imply for the hypothesis]
 **Files to modify:** [list of files that will be created or changed]
@@ -142,6 +299,11 @@ If no human proposal exists and human says "propose" or leaves PLAN blank:
 **Verify command:** [command that extracts metric, if fast-loop mode]
 **Guard command:** [regression check command, if fast-loop mode]
 ```
+
+The `**Effort level:**` and `**Alternatives considered:**` fields are
+required in new PLAN blocks going forward. Cycle-1 blocks written before
+the feature landed remain valid — downstream tools must tolerate both
+the old (9-field) and new (11-field) shapes.
 
 3. Update `## Status: WAITING_HUMAN` and `## Phase: PLAN`
 4. Run `bash scripts/compile_rsd.sh`

--- a/README.md
+++ b/README.md
@@ -91,11 +91,23 @@ PLAN → [you approve] → EXECUTE → INTERPRET → [you approve] → next cycl
 |---------|-------------|-----------|
 | Main loop — reads RSD state, runs the current phase | `/research` | `$research` |
 | Anchor protocol to an in-progress project (existing LaTeX + git + logs) | `/research:adopt` | `$research-adopt` |
-| Interactive experiment design wizard | `/research:plan` | `$research-plan` |
+| Interactive experiment design wizard (optional `--effort low\|middle\|high`) | `/research:plan` | `$research-plan` |
 | Run experiments (fast-loop or manual) | `/research:execute` | `$research-execute` |
 | Read local papers or search arxiv/web | `/research:context` | `$research-context` |
 | Search + build structured literature survey | `/research:context search <topic>` | `$research-context search <topic>` |
 | Write / edit / compile a venue-formatted LaTeX paper from RSD | `/research:paper` | `$research-paper` |
+
+### Effort levels for `/research:plan`
+
+`/research:plan` supports an optional `--effort` flag that controls how widely the AI explores before proposing an experiment. Default is `low` (current behavior).
+
+| Level | Behavior |
+|-------|----------|
+| `low` (default) | One proposal tied to your stated goal. Backward-compatible. |
+| `middle` | Generates 2-3 adjacent candidates, silently picks the best, logs the rejected ones under `Alternatives considered:` in the PLAN block. |
+| `high` | Cost gate first, then generates 5-8 wild candidates spanning multiple sub-topics — including at least one cross-field / unconventional candidate (e.g. Genetic Algorithms for prompt optimization) when plausible. Presents all candidates for you to pick. Every candidate cites a knowledge source. |
+
+Use `low` for incremental work where you already know what you want. Use `high` early in a project when you have a broad topic and want surprising directions.
 
 Codex alias note:
 - If installed with the current bootstrap, Codex also exposes `$research:adopt`, `$research:plan`, `$research:execute`, `$research:context`, and `$research:paper` as alias skill names.


### PR DESCRIPTION
## Summary

Adds an `--effort low|middle|high` flag to `/research:plan` (and the Codex mirrors) so users can dial the ideation breadth before committing to one experiment proposal. Default is `low` — fully backward-compatible.

- **low** (default) — current behavior. One proposal tied to the user's stated goal.
- **middle** — generate 2-3 adjacent candidates, silently pick the best, log rejected ones under `Alternatives considered:`.
- **high** — fire a cost gate, optionally offer `/research:context search` if SURVEY.md is thin, generate 5-8 wild candidates spanning 3+ sub-topics with at least one cross-field / unconventional candidate (e.g. GA for prompt optimization) when plausible, score on novelty/feasibility/relevance, present via interactive selection, user picks. "You pick" delegation option falls back to the highest combined score.

Anti-gaming guarantees preserved at every effort level:
- Every candidate must cite `Grounded in:` (knowledge source or explicit `novel — no prior work` marker).
- Final PLAN block is always ONE experiment with ONE prediction and ONE metric — effort affects ideation, not output shape.
- Cross-field candidates require a 1-sentence analogy explaining why the borrowed mechanism plausibly applies.

Effort level is **per-invocation** and **orthogonal** to Mode A (human-proposed) vs Mode B (AI-proposed): a human-seeded core idea with `--effort high` means "take my idea and explore wild variations of it".

## Phasing (3 reverttable commits)

1. `586774c` — protocol + PLAN block template (`phase-protocol.md` only; flag is inert)
2. `ae1cda0` — dispatcher (`plan.md`) + both Codex mirrors wire the flag in
3. `5deab36` — README Commands table + Effort levels subsection

## Test plan

- [ ] Backward compat: `/research:plan` with no flag on an existing RSD produces the same output as before, plus the two new optional fields (`Effort level: low`, `Alternatives considered: N/A (low effort)`)
- [ ] `/research:plan --effort low "test goal"` — same behavior as no-flag case
- [ ] `/research:plan --effort middle "tool-use accuracy"` on a project with SURVEY.md — AI generates 2-3 candidates internally, silently picks one, logs alternatives, no user round trip
- [ ] `/research:plan --effort high "llm agents"` on a project WITHOUT SURVEY.md — AI offers `/research:context search` once, then runs the cost gate, then generates 5-8 candidates spanning multiple sub-topics including at least one cross-field candidate, presents via AskUserQuestion
- [ ] HIGH "you pick" path — user picks delegation option → AI selects highest combined score and writes alternatives with scores visible
- [ ] HIGH cost gate appears BEFORE candidate generation, single-shot
- [ ] Cross-field auditability: any GA / control-theory / etc. candidate includes the required 1-sentence analogy
- [ ] Codex parity: `$research-plan --effort high "test"` and `$research:plan --effort middle "test"` both pick up the flag and delegate to phase-protocol.md
- [ ] `/research:plan --effort bogus` rejects with "unknown effort level — use low, middle, or high"
- [ ] Anti-gaming audit: every candidate has `Grounded in:`; final PLAN has exactly one Prediction and one metric regardless of effort level

🤖 Generated with [Claude Code](https://claude.com/claude-code)