### PR TITLE
research: add --search N to scale HIGH effort literature search (200 default)

### DIFF
--- a/.agents/skills/research-colon-plan/SKILL.md
+++ b/.agents/skills/research-colon-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research:plan
-description: "Alias for the AnchoredAutoResearch Codex planning wizard. Equivalent intent to $research-plan. Supports --effort low|middle|high."
+description: "Alias for the AnchoredAutoResearch Codex planning wizard. Equivalent intent to $research-plan. Supports --effort low|middle|high and --search N for literature-pool size."
 version: 1.0.0
 ---
 
@@ -8,17 +8,28 @@ version: 1.0.0
 
 Use this skill when the user invokes `$research:plan` in Codex.
 
-Optional flag: `--effort low|middle|high` controls ideation breadth.
-Default is `low` (current behavior). See `### Effort levels` in
-`../research/references/phase-protocol.md` for the per-level protocol.
-Reject any other value with: "unknown effort level — use low, middle, or high".
+Optional flags:
+- `--effort low|middle|high` controls ideation breadth. Default is `low`
+  (current behavior). See `### Effort levels` in
+  `../research/references/phase-protocol.md` for the per-level protocol.
+  Reject any other value with: "unknown effort level — use low, middle,
+  or high".
+- `--search N` sets the literature discover-pool size when this
+  invocation triggers `/research:context search <topic>`. Integer in
+  `[10, 500]`; clamped. Default by effort: `low` ignores it, `middle`
+  honors if passed, `high` defaults to `N=200`. Deep-read count is
+  `min(30, N // 5)`. See `knowledge-sources.md` "Search mode" for the
+  two-tier protocol. Reject non-integer values with: "`--search` must
+  be a positive integer in 10..500".
 
 Follow the same workflow as the `research-plan` skill:
 1. Read `AGENTS.md`
 2. Read `RSD.md`
 3. Read `context/SOURCES.md` if it exists
-4. Parse `--effort` flag if present and branch on it per the
-   `### Effort levels` section in `../research/references/phase-protocol.md`
+4. Parse `--effort` and `--search` flags if present and branch on them
+   per the `### Effort levels` section in
+   `../research/references/phase-protocol.md` (LOW ignores `--search`,
+   MIDDLE honors if passed, HIGH defaults to `--search 200`)
 5. Follow the PLAN section in `../research/references/phase-protocol.md`
 6. Follow `../research/references/knowledge-sources.md`
 7. Write the PLAN entry (including `Effort level:` and

--- a/.agents/skills/research-plan/SKILL.md
+++ b/.agents/skills/research-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-plan
-description: "AnchoredAutoResearch planning wizard for Codex. Builds the PLAN section with scope, metrics, verify/guard commands, predictions, and human approval gates. Supports --effort low|middle|high."
+description: "AnchoredAutoResearch planning wizard for Codex. Builds the PLAN section with scope, metrics, verify/guard commands, predictions, and human approval gates. Supports --effort low|middle|high and --search N for literature-pool size."
 version: 1.0.0
 ---
 
@@ -8,10 +8,19 @@ version: 1.0.0
 
 Use this skill when the user invokes `$research-plan` in Codex.
 
-Optional flag: `--effort low|middle|high` controls ideation breadth.
-Default is `low` (current behavior). See `### Effort levels` in
-`../research/references/phase-protocol.md` for the per-level protocol.
-Reject any other value with: "unknown effort level — use low, middle, or high".
+Optional flags:
+- `--effort low|middle|high` controls ideation breadth. Default is `low`
+  (current behavior). See `### Effort levels` in
+  `../research/references/phase-protocol.md` for the per-level protocol.
+  Reject any other value with: "unknown effort level — use low, middle,
+  or high".
+- `--search N` sets the literature discover-pool size when this
+  invocation triggers `/research:context search <topic>`. Integer in
+  `[10, 500]`; clamped. Default by effort: `low` ignores it, `middle`
+  honors if passed, `high` defaults to `N=200`. Deep-read count is
+  `min(30, N // 5)`. See `knowledge-sources.md` "Search mode" for the
+  two-tier protocol. Reject non-integer values with: "`--search` must
+  be a positive integer in 10..500".
 
 ## MANDATORY: Read Protocol Before Any Action
 
@@ -24,7 +33,10 @@ Reject any other value with: "unknown effort level — use low, middle, or high"
 ## Execution
 
 1. Treat any remaining user text as inline goal or planning context.
-   Parse `--effort low|middle|high` if present (default `low`).
+   Parse `--effort low|middle|high` (default `low`) and `--search N`
+   (integer in `[10, 500]`, clamped). Resolve the effective `--search`
+   value per effort level: LOW ignores, MIDDLE honors if passed, HIGH
+   defaults to `N=200`.
 2. Verify the project is in PLAN or can safely enter PLAN from INIT
 3. Read unread sources in `context/`
 4. Branch on effort level per `### Effort levels` in

--- a/.claude/commands/research/plan.md
+++ b/.claude/commands/research/plan.md
@@ -1,7 +1,7 @@
 ---
 name: research:plan
-description: "Interactive experiment design wizard. Builds a complete PLAN section for RSD: Goal→Scope→Metric→Verify→Guard→Prediction→Confirm. Supports --effort low|middle|high."
-argument-hint: "[goal description] [--effort low|middle|high]"
+description: "Interactive experiment design wizard. Builds a complete PLAN section for RSD: Goal→Scope→Metric→Verify→Guard→Prediction→Confirm. Supports --effort low|middle|high and --search N for literature-pool size."
+argument-hint: "[goal description] [--effort low|middle|high] [--search N]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate before reading the protocol.
@@ -10,13 +10,27 @@ EXECUTE IMMEDIATELY — do not deliberate before reading the protocol.
 
 Extract from $ARGUMENTS:
 - Goal text — if user provides it inline, use as starting point
-- Any flags: `--scope`, `--metric`, `--verify`, `--guard`, `--mode`, `--effort`
+- Any flags: `--scope`, `--metric`, `--verify`, `--guard`, `--mode`, `--effort`, `--search`
 - `--effort low|middle|high` — exploration breadth for the ideation step.
   Default: `low` (backward-compatible, same as before the flag was added).
   See `phase-protocol.md` `### Effort levels` for the per-level protocol.
   Validate: if `--effort` is present, value MUST be one of `low`, `middle`,
   `high`. Reject any other value with: "unknown effort level — use low,
   middle, or high".
+- `--search N` — size of the literature discover-pool when this invocation
+  triggers `/research:context search <topic>`. `N` is an integer in
+  `[10, 500]`; values outside the range are clamped and the effective
+  value is reported back to the user. Default behavior by effort level:
+  - `--effort low` → `--search` is silently ignored (LOW never runs a
+    search)
+  - `--effort middle` → honored if passed; otherwise the pre-flag
+    "small pool" default applies (`N ≤ 10`)
+  - `--effort high` → default `N = 200`; user override wins
+  Deep-read count always follows `min(30, N // 5)` per
+  `knowledge-sources.md` (the `--search` flag never changes the
+  deep-read ceiling). Validate: if `--search` is present, its value
+  MUST parse as a positive integer. Reject anything else with:
+  "`--search` must be a positive integer in 10..500".
 
 ## Execution
 
@@ -39,23 +53,33 @@ If no goal inline, ask:
 - Read codebase structure and existing code
 - Read knowledge sources — what does prior work suggest?
 - Identify relevant tools, frameworks, metrics
+- **Resolve the effective `--search N` value** before any context-search
+  call (see the Argument Parsing block for the per-effort default table).
+  When HIGH effort triggers `/research:context search`, always forward
+  the effective `--search` value so `knowledge-sources.md`'s two-tier
+  discover/deep-read protocol kicks in.
 - **Branch on effort level** (see `phase-protocol.md` `### Effort levels`
   for the full per-level protocol):
   - `low` (default) → one proposal tied to the user's stated goal. No
-    candidate generation. Continue to Step 3.
-  - `middle` → optionally offer `/research:context search` if SURVEY.md
-    is thin; generate 2-3 adjacent candidates; rank by
+    candidate generation, no literature search. Continue to Step 3.
+  - `middle` → optionally offer `/research:context search <topic>
+    [--search N]` if SURVEY.md is thin (forward the user's `--search` if
+    passed); generate 2-3 adjacent candidates; rank by
     relevance × novelty × feasibility; silently pick the best; remember
     the rejected candidates for Step 7's `**Alternatives considered:**`
     field.
-  - `high` → fire the cost gate FIRST (`"This will use significantly more
-    tokens. Proceed?"`); on yes, optionally offer `/research:context
-    search`; generate 5-8 candidates spanning 3+ sub-topics with at
-    least one combination candidate and at least one cross-field
-    candidate when plausible; score each on novelty/feasibility/relevance
-    (1-5 each); present the top 5-8 via `AskUserQuestion` with a "You
-    pick (highest combined score)" delegation option; use the chosen
-    candidate as the seed for Steps 3-6.
+  - `high` → fire the cost gate FIRST (cost warning must include the
+    effective discover-pool size, e.g. `"This will use significantly
+    more tokens (wide search of N=200 papers)."`); on yes, run
+    `/research:context search <topic> --search <N>` if the topic is not
+    already well-covered in SURVEY.md (default N=200; honor user's
+    `--search` override); generate 5-8 candidates spanning 3+
+    sub-topics with at least one combination candidate and at least one
+    cross-field candidate when plausible; score each on
+    novelty/feasibility/relevance (1-5 each); present the top 5-8 via
+    `AskUserQuestion` with a "You pick (highest combined score)"
+    delegation option; use the chosen candidate as the seed for
+    Steps 3-6.
 
 ### Step 3: Define Scope
 Present scope options:

--- a/.claude/skills/research/references/knowledge-sources.md
+++ b/.claude/skills/research/references/knowledge-sources.md
@@ -108,6 +108,13 @@ Based on the gaps and limitations above:
 - **Limitations:** [what it doesn't address or does poorly]
 - **Relevance to us:** [why this matters for our research goal]
 - **Source:** [URL or file path]
+
+## Screened (abstract-only)
+*Papers discovered during the search but not deep-read. Relevance-ranked; deep-read papers live in Per-Paper Notes above. Populated when `/research:context search` is invoked with `--search N > 10`.*
+
+| Paper | Venue / Year | 1-line relevance to topic |
+|-------|--------------|---------------------------|
+| [title](url) | [venue, year] | [why this was surfaced by the search] |
 ```
 
 ### When to Update SURVEY.md
@@ -184,17 +191,55 @@ When invoked standalone:
 6. If `RSD.md` exists, update the `## Knowledge Sources` table
 7. Report to human: what was read, key findings, updated gaps/directions
 
-### Search mode (`/research:context search <topic>`): Web search + analysis
-1. Search arxiv, Google Scholar, web for the given topic
-2. Download or save URLs for top 5-10 relevant results
-3. Read abstracts/summaries — for each paper extract: methodology, key result, strengths, limitations
-4. Update `context/SOURCES.md` index with found sources
-5. Create or update `context/SURVEY.md` with structured analysis:
-   - Methods Landscape table (method | core idea | strengths | limitations | best result)
-   - Key findings, what works, what doesn't work
-   - Open problems / research gaps
-   - State of the art table
-   - Suggested research directions grounded in the gaps
-   - Per-paper notes (methodology, result, strengths, limitations, relevance)
-6. If `RSD.md` exists, update the `## Knowledge Sources` table
-7. Report to human: survey summary, top findings, suggested directions
+### Search mode (`/research:context search <topic> [--search N]`): Web search + analysis
+
+The `--search N` flag sets the size of the **discover pool** — how many unique
+title + abstract hits the search collects before ranking.
+Default: `10`. Range: `10`-`500` (values outside the range are clamped and the
+actual used value is reported to the user).
+
+**Two-tier operation** (the reason `--search N` is decoupled from deep-read count):
+
+- **Discover** (cheap) — collect up to `N` unique title + abstract hits via web
+  search across arxiv, Google Scholar, and the general web.
+- **Deep-read** (expensive) — read the top `min(30, N // 5)` papers in full,
+  ranked by relevance.
+
+Rationale: title-level discovery scales cheaply (≈1 search query per 10 results),
+but full-text reading is token-heavy with diminishing returns past ~30 papers.
+The two-tier split gives you breadth coverage via the Screened section and depth
+coverage via Per-Paper Notes.
+
+**Protocol:**
+
+1. **Scale query count to `N`:**
+   - `N ≤ 20` → 3-5 queries (same as the pre-flag default)
+   - `20 < N ≤ 100` → 8-15 queries spanning keyword variants and synonyms
+   - `100 < N ≤ 500` → 15-30 queries spanning sub-topics, method families,
+     benchmarks, and adjacent literatures
+2. **Discover phase:** for each query, search arxiv / Google Scholar / web.
+   Dedupe by paper URL or title. Collect `{title, abstract, venue, year, url}`
+   for up to `N` unique hits. Stop early if fewer unique hits exist than `N`
+   (the topic is simply smaller than the requested pool).
+3. **Rank** the discovered pool by relevance to the topic, using title + abstract.
+4. **Deep-read phase:** select the top `min(30, N // 5)` papers. For each, read
+   the full abstract (and the conclusion if available) and extract methodology,
+   key result, strengths, limitations.
+5. Update `context/SOURCES.md` index with **all** discovered sources (both
+   deep-read and screened).
+6. Update `context/SURVEY.md` with structured analysis:
+   - **Methods Landscape** table — from the deep-read subset only
+   - **Key findings, what works, what doesn't work** — from deep-read subset
+   - **Open problems / research gaps** — from deep-read subset
+   - **State of the art** table — from deep-read subset
+   - **Suggested research directions** — grounded in the gaps
+   - **Per-Paper Notes** — one full entry per deep-read paper
+   - **Screened (abstract-only)** — one row per discovered-but-not-deep-read
+     paper with title, venue/year, and 1-line relevance (skip this section
+     entirely when `N ≤ 10`)
+7. If `RSD.md` exists, update the `## Knowledge Sources` table. Deep-read papers
+   get full "Key Takeaway" entries. Screened papers can be summarized as a
+   single row: `screened <M> additional papers via /research:context search`.
+8. **Report to human:** survey summary, top findings, how many were deep-read
+   vs screened, and suggested directions. Always print the effective `--search`
+   value used (including clamps), so the user knows what actually happened.

--- a/.claude/skills/research/references/phase-protocol.md
+++ b/.claude/skills/research/references/phase-protocol.md
@@ -171,21 +171,40 @@ Wide exploration mode with explicit cross-field ideation and a user
 selection step. This is the token-heavy mode — gate it behind a cost
 prompt at the start.
 
+**Search-pool size (`--search N`)**: HIGH runs a wide literature search
+via `/research:context search` by default. The discover-pool size is:
+- `N = 200` when the user did not pass `--search` on `/research:plan`
+- `N = <user value>` (clamped to `10`-`500`) when `--search N` was passed
+Deep-read count follows `min(30, N // 5)` per `knowledge-sources.md`.
+MIDDLE may also inherit a user-passed `--search N` when it offers the
+search; LOW never runs a search and ignores `--search` silently.
+
 1. **Cost gate** (MANDATORY first step): Before any candidate generation,
    tell the user:
    > "High-effort exploration will generate 5-8 candidate directions
-   > spanning multiple sub-topics, and may invoke web search. This can
-   > use significantly more tokens than low/middle. Proceed? (yes / cancel)"
+   > spanning multiple sub-topics, and runs a wide literature search
+   > (discover pool = `<N>` papers via `/research:context search`, with
+   > top `<min(30, N // 5)>` deep-read). This can use significantly more
+   > tokens than low/middle. Proceed? (yes / cancel)"
+   - Substitute `<N>` with the effective value (200 default, or the
+     user's `--search N` override).
    - `cancel` → STOP, tell the user to rerun with `--effort low` or
-     `--effort middle` if they want to continue
+     `--effort middle` if they want to continue, or pass a smaller
+     `--search N` (e.g. `--search 50`) if the cost is the blocker.
    - `yes` → continue to step 2
 
-2. **SURVEY.md pre-check** (same as MIDDLE step 2, but mandatory to ask):
-   If `context/SURVEY.md` is missing or has no entries for the detected
-   sub-topic, offer once to run `/research:context search <topic>` first.
-   Record the answer. If the user says no/skip, proceed with whatever is
-   in `context/` and mark affected candidates with the explicit "novel —
-   no prior work found" marker.
+2. **SURVEY.md pre-check + wide search**: If `context/SURVEY.md` is
+   missing OR has no entries for the detected sub-topic, automatically
+   run (no prompt needed — the cost gate already confirmed):
+   ```
+   /research:context search <topic> --search <N>
+   ```
+   where `<N>` is the effective search-pool size from the Search-pool
+   note above. If SURVEY.md already covers the sub-topic and the user
+   did NOT pass `--search`, skip the search; if the user DID pass
+   `--search N`, run the search anyway to honor the explicit request.
+   If for any reason the search is skipped entirely, mark affected
+   candidates with the explicit "novel — no prior work found" marker.
 
 3. **Wild candidate generation**: Enumerate 5-8 candidate directions
    spanning multiple sub-topics. The protocol REQUIRES that the set:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ PLAN → [you approve] → EXECUTE → INTERPRET → [you approve] → next cycl
 |---------|-------------|-----------|
 | Main loop — reads RSD state, runs the current phase | `/research` | `$research` |
 | Anchor protocol to an in-progress project (any of: LaTeX draft, git history, logs/, or knowledge sources) | `/research:adopt` | `$research-adopt` |
-| Interactive experiment design wizard (optional `--effort low\|middle\|high`) | `/research:plan` | `$research-plan` |
+| Interactive experiment design wizard (optional `--effort low\|middle\|high`, `--search N`) | `/research:plan` | `$research-plan` |
 | Run experiments (fast-loop or manual) | `/research:execute` | `$research-execute` |
 | Read local papers or search arxiv/web | `/research:context` | `$research-context` |
 | Search + build structured literature survey | `/research:context search <topic>` | `$research-context search <topic>` |
@@ -127,15 +127,28 @@ PLAN → [you approve] → EXECUTE → INTERPRET → [you approve] → next cycl
 
 ### Effort levels for `/research:plan`
 
-`/research:plan` supports an optional `--effort` flag that controls how widely the AI explores before proposing an experiment. Default is `low` (current behavior).
+`/research:plan` supports two optional flags that control how widely the AI explores before proposing an experiment:
 
-| Level | Behavior |
-|-------|----------|
-| `low` (default) | One proposal tied to your stated goal. Backward-compatible. |
-| `middle` | Generates 2-3 adjacent candidates, silently picks the best, logs the rejected ones under `Alternatives considered:` in the PLAN block. |
-| `high` | Cost gate first, then generates 5-8 wild candidates spanning multiple sub-topics — including at least one cross-field / unconventional candidate (e.g. Genetic Algorithms for prompt optimization) when plausible. Presents all candidates for you to pick. Every candidate cites a knowledge source. |
+- **`--effort low|middle|high`** — ideation breadth. Default is `low` (current behavior).
+- **`--search N`** — literature discover-pool size. Integer in `[10, 500]`, clamped. Default depends on `--effort`.
+
+| Level | Ideation | Default `--search` | Behavior |
+|-------|----------|--------------------|----------|
+| `low` (default) | 1 proposal | — (no search) | One proposal tied to your stated goal. Backward-compatible. |
+| `middle` | 2-3 candidates, silent pick | 10 (honors `--search` if passed) | Generates adjacent candidates, silently picks the best, logs the rejected ones under `Alternatives considered:`. |
+| `high` | 5-8 wild candidates, you pick | **200** (user override wins) | Cost gate first, then generates wild candidates spanning multiple sub-topics — including at least one cross-field / unconventional candidate (e.g. Genetic Algorithms for prompt optimization) when plausible. Presents all candidates for you to pick. Every candidate cites a knowledge source. |
 
 Use `low` for incremental work where you already know what you want. Use `high` early in a project when you have a broad topic and want surprising directions.
+
+**About `--search N`:** when triggered, `/research:plan` calls `/research:context search <topic> --search N` under the hood. The search runs a **two-tier protocol**: it discovers up to `N` papers via title+abstract, then deep-reads the top `min(30, N // 5)` in full. At `N=200` you get 200 screened + 30 deep-read. Deep-read papers populate the Methods Landscape and Per-Paper Notes in `context/SURVEY.md`; screened papers go into a `## Screened (abstract-only)` table so they're still visible but don't burn the token budget. Max allowed is `--search 500`.
+
+Examples:
+```text
+/research:plan --effort high                    # HIGH with default 200-paper wide search
+/research:plan --effort high --search 300       # HIGH, scaled up to 300 screened
+/research:plan --effort high --search 50        # HIGH, scaled down (cheaper)
+/research:plan --effort middle --search 50      # MIDDLE with an unusually wide search
+```
 
 Codex alias note:
 - If installed with the current bootstrap, Codex also exposes `$research:adopt`, `$research:plan`, `$research:execute`, `$research:context`, and `$research:paper` as alias skill names.


### PR DESCRIPTION
## Summary

Adds a `--search N` flag to `/research:plan` (and the Codex mirrors) that controls the literature discover-pool size when HIGH effort triggers a wide web search. Fixes user-reported issue where HIGH effort was capped at 5-10 papers because it inherited the pre-effort-levels default.

**New behavior at HIGH effort**: the search now defaults to **200 discovered + 30 deep-read** instead of the old 5-10 cap. User can override with `--search N` (integer, clamped to `[10, 500]`).

## How it works — two-tier protocol

The underlying `/research:context search <topic>` now accepts `--search N` and runs in two phases:

1. **Discover (cheap)** — collect up to `N` unique title+abstract hits via arxiv / Google Scholar / web. Scales linearly with `N` (≈1 query per 10 results).
2. **Deep-read (expensive)** — read the top `min(30, N // 5)` papers in full and extract methodology, results, strengths, limitations.

Deep-read papers populate `Methods Landscape` + `Per-Paper Notes` in `SURVEY.md`. Discovered-but-not-deep-read papers populate a new `## Screened (abstract-only)` section so the human reviewer can see what was screened without burning the token budget on 200 full reads.

## Per-effort defaults

| Level | Default `--search` | Notes |
|-------|--------------------|-------|
| `low` | — (no search) | `--search` silently ignored |
| `middle` | 10 (honors user override) | Two-tier kicks in only if user passes `--search > 10` |
| `high` | **200** (user override wins) | Cost gate at start tells user the effective N |

Deep-read is always `min(30, N // 5)`: at `N=10` you deep-read 2, at `N=200` you deep-read 30, at `N=500` you deep-read 30 (capped).

## Phasing (3 reverttable commits)

1. `5d6e9f1` — `knowledge-sources.md`: add `--search N` protocol + two-tier flow + `## Screened (abstract-only)` SURVEY.md section
2. `83fdbf7` — `phase-protocol.md` HIGH effort + dispatcher + both Codex mirrors wire the flag through
3. `065287e` — README Effort levels subsection + Commands table

## Test plan

- [ ] Backward compat: `/research:plan --effort low "goal"` → no search runs, `--search` silently ignored even if passed
- [ ] `/research:plan --effort middle "goal"` (no `--search`) → SURVEY.md pre-check offers search with default `N=10`, same as before
- [ ] `/research:plan --effort middle --search 50 "goal"` → MIDDLE honors the user override, two-tier kicks in, 50 screened + 10 deep-read
- [ ] `/research:plan --effort high "llm agents"` (no `--search`) → cost gate states "N=200 papers, top 30 deep-read", on yes the wide search runs
- [ ] `/research:plan --effort high --search 300 "llm agents"` → cost gate shows 300, deep-read 30 (still capped at min(30, 300/5))
- [ ] `/research:plan --effort high --search 50 "llm agents"` → cost gate shows 50, deep-read 10
- [ ] `/research:plan --effort high --search 9999` → clamps to 500, reports clamp to user
- [ ] `/research:plan --effort high --search abc` → rejects with "`--search` must be a positive integer in 10..500"
- [ ] `/research:context search "topic" --search 200` (direct call) → two-tier runs, SURVEY.md gets both Per-Paper Notes (30 entries) and Screened (170 rows)
- [ ] `/research:context search "topic"` (no `--search`) → default N=10 behavior unchanged, no Screened section written
- [ ] Codex parity: `$research-plan --effort high --search 150 "topic"` works the same; both `$research-plan` and `$research:plan` aliases pick up the flag
- [ ] SURVEY.md template: `## Screened (abstract-only)` section renders as a table, comes after `## Per-Paper Notes`
- [ ] Anti-gaming: every deep-read candidate still has `Grounded in:`; final PLAN still has exactly one Prediction and one metric regardless of discover-pool size

## Not in scope

- INIT phase still uses the old `5-10` default (line 16 of `phase-protocol.md`). If you want INIT to also scale up, that's a separate change.
- No concurrency — the discover phase is still sequential web search calls. Scaling beyond `N=500` would benefit from parallelism, but 500 is the hard cap for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)